### PR TITLE
Add filename format presets and dropdown selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ python run_sorter.py config.yaml patterns.yaml
 ## Hinweise
 - Poppler/Tesseract-Pfade unter Windows in der GUI/`config.yaml` setzen.
 - Supplier-spezifische Regeln in `patterns/suppliers/*.yaml` anpassen.
-- Dateiname des Ausgabe-PDFs via `output_filename_format` steuern (Platzhalter wie `{date}`, `{supplier_safe}`, `{invoice_no_safe}`, `{hash_short}`, `{original_name_safe}`, `{target_subdir_safe}`).
+- Dateiname des Ausgabe-PDFs via `output_filename_format` steuern; mehrere Varianten können in `output_filename_formats` gepflegt und in der GUI per Dropdown ausgewählt werden (Platzhalter wie `{date}`, `{supplier_safe}`, `{invoice_no_safe}`, `{hash_short}`, `{original_name_safe}`, `{target_subdir_safe}`).
 
 
 ### Neu in v4

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,17 @@
 input_dir: G:/Test/in
 output_dir: G:/Test/out
 output_filename_format: "{date}_{supplier_safe}_Re-{date}"
+output_filename_formats:
+  - label: "Standard (Datum_Lieferant)"
+    pattern: "{date}_{supplier_safe}_Re-{date}"
+  - label: "Datum_Lieferant_Rechnungsnummer"
+    pattern: "{date}_{supplier_safe}_Re-{invoice_no_safe}"
+  - label: "Lieferant_Rechnungsnummer"
+    pattern: "{supplier_safe}_Re-{invoice_no_safe}"
+  - label: "Lieferant_Datum_Betrag"
+    pattern: "{supplier_safe}_{date}_{gross}"
+  - label: "Datum_Originalname_Hash"
+    pattern: "{date}_{original_name_safe}_{hash_short}"
 unknown_dir_name: unbekannt
 tesseract_cmd: C:/Program Files/Tesseract-OCR/tesseract.exe
 poppler_path: C:/poppler-25.07.0


### PR DESCRIPTION
## Summary
- add five suggested output filename presets to the configuration and keep them persisted
- allow the GUI to pick an output filename preset via dropdown while keeping custom strings editable
- let the sorter fall back to the first configured preset when no explicit format is set

## Testing
- python -m compileall gui_app.py sorter.py

------
https://chatgpt.com/codex/tasks/task_e_68d0ef3f8d108327a4298f0886de8512