### PR TITLE
Add filename format presets, dropdown selection, and tool info panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ python run_sorter.py config.yaml patterns.yaml
 ## Hinweise
 - Poppler/Tesseract-Pfade unter Windows in der GUI/`config.yaml` setzen.
 - Supplier-spezifische Regeln in `patterns/suppliers/*.yaml` anpassen.
-- Dateiname des Ausgabe-PDFs via `output_filename_format` steuern (Platzhalter wie `{date}`, `{supplier_safe}`, `{invoice_no_safe}`, `{hash_short}`, `{original_name_safe}`, `{target_subdir_safe}`).
+- Dateiname des Ausgabe-PDFs via `output_filename_format` steuern; mehrere Varianten können in `output_filename_formats` gepflegt und in der GUI per Dropdown ausgewählt werden (Platzhalter wie `{date}`, `{supplier_safe}`, `{invoice_no_safe}`, `{hash_short}`, `{original_name_safe}`, `{target_subdir_safe}`).
 
 
 ### Neu in v4

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,17 @@
 input_dir: G:/Test/in
 output_dir: G:/Test/out
 output_filename_format: "{date}_{supplier_safe}_Re-{date}"
+output_filename_formats:
+  - label: "Standard (Datum_Lieferant)"
+    pattern: "{date}_{supplier_safe}_Re-{date}"
+  - label: "Datum_Lieferant_Rechnungsnummer"
+    pattern: "{date}_{supplier_safe}_Re-{invoice_no_safe}"
+  - label: "Lieferant_Rechnungsnummer"
+    pattern: "{supplier_safe}_Re-{invoice_no_safe}"
+  - label: "Lieferant_Datum_Betrag"
+    pattern: "{supplier_safe}_{date}_{gross}"
+  - label: "Datum_Originalname_Hash"
+    pattern: "{date}_{original_name_safe}_{hash_short}"
 unknown_dir_name: unbekannt
 tesseract_cmd: C:/Program Files/Tesseract-OCR/tesseract.exe
 poppler_path: C:/poppler-25.07.0

--- a/gui_app.py
+++ b/gui_app.py
@@ -25,6 +25,30 @@ if sorter is not None and hasattr(sorter, "DEFAULT_OUTPUT_FILENAME_FORMAT"):
 else:
     DEFAULT_FILENAME_FMT = "{date}_{supplier_safe}_Re-{date}"
 
+CUSTOM_FILENAME_LABEL = "Benutzerdefiniert"
+DEFAULT_FILENAME_FORMAT_PRESETS = (
+    {
+        "label": "Standard (Datum_Lieferant)",
+        "pattern": DEFAULT_FILENAME_FMT,
+    },
+    {
+        "label": "Datum_Lieferant_Rechnungsnummer",
+        "pattern": "{date}_{supplier_safe}_Re-{invoice_no_safe}",
+    },
+    {
+        "label": "Lieferant_Rechnungsnummer",
+        "pattern": "{supplier_safe}_Re-{invoice_no_safe}",
+    },
+    {
+        "label": "Lieferant_Datum_Betrag",
+        "pattern": "{supplier_safe}_{date}_{gross}",
+    },
+    {
+        "label": "Datum_Originalname_Hash",
+        "pattern": "{date}_{original_name_safe}_{hash_short}",
+    },
+)
+
 class TextQueueWriter(io.TextIOBase):
     """Leitet stdout/stderr-Text in eine Queue, damit das GUI Logs anzeigen kann."""
     def __init__(self, q: queue.Queue, tag: str = "INFO"):
@@ -46,6 +70,7 @@ class App(tk.Tk):
         self.title(APP_TITLE)
         self.geometry("1080x760")
         self.minsize(980, 680)
+        self.protocol("WM_DELETE_WINDOW", self._exit_app)
 
         self.queue = queue.Queue()
         self.worker_thread = None
@@ -69,8 +94,28 @@ class App(tk.Tk):
         root = ttk.Frame(self)
         root.pack(fill=tk.BOTH, expand=True, padx=12, pady=12)
 
+        main_area = ttk.Frame(root)
+        main_area.pack(fill=tk.BOTH, expand=True)
+
+        left_column = ttk.Frame(main_area)
+        left_column.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
+
+        info_column = ttk.Frame(main_area)
+        info_column.pack(side=tk.RIGHT, fill=tk.Y, padx=(12, 0))
+
+        info_frame = ttk.LabelFrame(info_column, text="Tool-Info")
+        info_frame.pack(fill=tk.X, anchor=tk.N)
+        info_text = (
+            "Name: PDF Rechnungs Changer\n"
+            "Autor: Markus Dickscheit\n"
+            "Open Source Verwendung auf eigene Gefahr"
+        )
+        ttk.Label(info_frame, text=info_text, justify=tk.LEFT, wraplength=220).pack(
+            fill=tk.X, padx=8, pady=8
+        )
+
         # Konfiguration
-        cfg_frame = ttk.LabelFrame(root, text="Konfiguration")
+        cfg_frame = ttk.LabelFrame(left_column, text="Konfiguration")
         cfg_frame.pack(fill=tk.X, padx=0, pady=(0, 10))
 
         # Zeile 1: input/output
@@ -78,6 +123,10 @@ class App(tk.Tk):
         self.var_output = tk.StringVar()
         self.var_unknown = tk.StringVar(value="unbekannt")
         self.var_filename_fmt = tk.StringVar(value=DEFAULT_FILENAME_FMT)
+        self.var_filename_fmt_choice = tk.StringVar(value=CUSTOM_FILENAME_LABEL)
+        self.custom_format_label = CUSTOM_FILENAME_LABEL
+        self.filename_format_presets = []
+        self._updating_filename_format = False
 
         row1 = ttk.Frame(cfg_frame)
         row1.pack(fill=tk.X, pady=6)
@@ -93,8 +142,20 @@ class App(tk.Tk):
         ttk.Entry(row1, textvariable=self.var_unknown, width=30).grid(row=2, column=1, sticky=tk.W, pady=(6,0))
 
         ttk.Label(row1, text="Dateiname-Muster:").grid(row=3, column=0, sticky=tk.W, pady=(6,0))
-        ttk.Entry(row1, textvariable=self.var_filename_fmt, width=70).grid(row=3, column=1, sticky=tk.W, pady=(6,0))
+        self.cmb_filename_fmt = ttk.Combobox(
+            row1,
+            textvariable=self.var_filename_fmt_choice,
+            width=40,
+            state="readonly",
+        )
+        self.cmb_filename_fmt.grid(row=3, column=1, sticky=tk.W, pady=(6,0))
         ttk.Button(row1, text="Standard", command=self._reset_filename_format).grid(row=3, column=2, padx=6, pady=(6,0))
+        ttk.Label(row1, text="Muster-Vorschau:").grid(row=4, column=0, sticky=tk.W, pady=(6,0))
+        self.entry_filename_fmt = ttk.Entry(row1, textvariable=self.var_filename_fmt, width=70)
+        self.entry_filename_fmt.grid(row=4, column=1, columnspan=2, sticky=tk.W, pady=(6,0))
+        self._set_filename_format_options([], DEFAULT_FILENAME_FMT)
+        self.var_filename_fmt.trace_add("write", self._on_filename_format_var_changed)
+        self.cmb_filename_fmt.bind("<<ComboboxSelected>>", self._on_filename_format_choice)
 
         # Zeile 2: OCR / Poppler / Tesseract / Sprache
         row2 = ttk.Frame(cfg_frame)
@@ -156,19 +217,21 @@ class App(tk.Tk):
         ttk.Button(row4, text="Laden", command=self._choose_patterns).grid(row=2, column=2, padx=6, pady=(6,0))
 
         # Aktionen
-        actions = ttk.Frame(root)
+        actions = ttk.Frame(left_column)
         actions.pack(fill=tk.X, pady=(0,10))
         self.btn_save = ttk.Button(actions, text="Konfig speichern", command=self._save_config)
         self.btn_run = ttk.Button(actions, text="Verarbeiten starten", command=self._run_worker)
         self.btn_stop = ttk.Button(actions, text="Stop", command=self._stop_worker, state=tk.DISABLED)
         self.btn_preview = ttk.Button(actions, text="Vorschau laden…", command=self._preview_any_pdf)
+        self.btn_exit = ttk.Button(actions, text="Beenden", command=self._exit_app)
         self.btn_save.pack(side=tk.LEFT)
         self.btn_run.pack(side=tk.LEFT, padx=8)
         self.btn_stop.pack(side=tk.LEFT)
-        self.btn_preview.pack(side=tk.RIGHT)
+        self.btn_exit.pack(side=tk.RIGHT)
+        self.btn_preview.pack(side=tk.RIGHT, padx=(0, 8))
 
         # Notebook mit Tabs: Log, Vorschau, Fehler, Regex-Tester
-        nb = ttk.Notebook(root)
+        nb = ttk.Notebook(left_column)
         nb.pack(fill=tk.BOTH, expand=True)
         self.nb = nb
 
@@ -261,7 +324,125 @@ class App(tk.Tk):
             self.var_patterns_path.set(f)
 
     def _reset_filename_format(self):
-        self.var_filename_fmt.set(DEFAULT_FILENAME_FMT)
+        self._set_filename_format_options(None, DEFAULT_FILENAME_FMT)
+
+    def _default_filename_format_presets(self):
+        return [dict(item) for item in DEFAULT_FILENAME_FORMAT_PRESETS]
+
+    def _normalize_filename_format_presets(self, presets_raw):
+        presets = []
+        seen = set()
+
+        def add_entry(label, pattern):
+            if pattern is None:
+                return
+            pattern_str = str(pattern).strip()
+            if not pattern_str:
+                return
+            label_str = str(label).strip() if label is not None else ""
+            if not label_str:
+                label_str = pattern_str
+            key = (label_str, pattern_str)
+            if key in seen:
+                return
+            seen.add(key)
+            presets.append({"label": label_str, "pattern": pattern_str})
+
+        if isinstance(presets_raw, dict):
+            for label, pattern in presets_raw.items():
+                add_entry(label, pattern)
+        elif isinstance(presets_raw, list):
+            for item in presets_raw:
+                if isinstance(item, dict):
+                    label = (
+                        item.get("label")
+                        or item.get("name")
+                        or item.get("title")
+                        or item.get("id")
+                    )
+                    pattern = (
+                        item.get("pattern")
+                        or item.get("format")
+                        or item.get("template")
+                        or item.get("value")
+                    )
+                    add_entry(label, pattern)
+                elif isinstance(item, (list, tuple)) and len(item) >= 2:
+                    add_entry(item[0], item[1])
+                elif isinstance(item, str):
+                    add_entry(item, item)
+        return presets
+
+    def _ensure_custom_label_available(self):
+        values = list(self.cmb_filename_fmt.cget("values") or [])
+        if self.custom_format_label not in values:
+            values.append(self.custom_format_label)
+            self.cmb_filename_fmt.configure(values=values)
+
+    def _get_pattern_for_label(self, label):
+        for preset in self.filename_format_presets:
+            if preset.get("label") == label:
+                return preset.get("pattern")
+        return None
+
+    def _get_label_for_pattern(self, pattern):
+        for preset in self.filename_format_presets:
+            if preset.get("pattern") == pattern:
+                return preset.get("label")
+        return None
+
+    def _set_filename_format_options(self, presets_raw, selected_pattern):
+        if presets_raw is None:
+            presets = [dict(item) for item in self.filename_format_presets]
+        else:
+            presets = self._normalize_filename_format_presets(presets_raw)
+        if not presets:
+            presets = self._default_filename_format_presets()
+        self.filename_format_presets = presets
+        values = [item.get("label", "") for item in presets]
+        if self.custom_format_label not in values:
+            values.append(self.custom_format_label)
+        self.cmb_filename_fmt.configure(values=values)
+
+        pattern = ""
+        if isinstance(selected_pattern, str):
+            pattern = selected_pattern.strip()
+        if not pattern and presets:
+            pattern = presets[0].get("pattern", DEFAULT_FILENAME_FMT)
+        label = self._get_label_for_pattern(pattern)
+        if label is None:
+            label = self.custom_format_label
+        self._updating_filename_format = True
+        self.var_filename_fmt_choice.set(label)
+        self.var_filename_fmt.set(pattern or DEFAULT_FILENAME_FMT)
+        self._updating_filename_format = False
+        if label == self.custom_format_label:
+            self._ensure_custom_label_available()
+
+    def _on_filename_format_choice(self, event=None):
+        if self._updating_filename_format:
+            return
+        label = self.var_filename_fmt_choice.get()
+        pattern = self._get_pattern_for_label(label)
+        if pattern is not None:
+            self._updating_filename_format = True
+            self.var_filename_fmt.set(pattern)
+            self._updating_filename_format = False
+        elif label == self.custom_format_label:
+            self._ensure_custom_label_available()
+
+    def _on_filename_format_var_changed(self, *args):
+        if self._updating_filename_format:
+            return
+        pattern = self.var_filename_fmt.get()
+        label = self._get_label_for_pattern(pattern)
+        self._updating_filename_format = True
+        if label is not None:
+            self.var_filename_fmt_choice.set(label)
+        else:
+            self._ensure_custom_label_available()
+            self.var_filename_fmt_choice.set(self.custom_format_label)
+        self._updating_filename_format = False
 
     # --------------------------
     # Tesseract-Sprachen ermitteln
@@ -306,11 +487,10 @@ class App(tk.Tk):
         self.var_input.set(cfg.get("input_dir", ""))
         self.var_output.set(cfg.get("output_dir", ""))
         self.var_unknown.set(cfg.get("unknown_dir_name", "unbekannt"))
-        fmt = cfg.get("output_filename_format")
-        if fmt:
-            self.var_filename_fmt.set(fmt)
-        else:
-            self.var_filename_fmt.set(DEFAULT_FILENAME_FMT)
+        self._set_filename_format_options(
+            cfg.get("output_filename_formats"),
+            cfg.get("output_filename_format"),
+        )
         self.var_tesseract.set(cfg.get("tesseract_cmd", ""))
         self.var_poppler.set(cfg.get("poppler_path", ""))
         self.var_use_ocr.set(bool(cfg.get("use_ocr", True)))
@@ -342,6 +522,23 @@ class App(tk.Tk):
         }
         fmt = (self.var_filename_fmt.get() or "").strip()
         cfg["output_filename_format"] = fmt or DEFAULT_FILENAME_FMT
+        if self.filename_format_presets:
+            presets_out = []
+            seen = set()
+            for item in self.filename_format_presets:
+                label = str(item.get("label", "")).strip()
+                pattern = str(item.get("pattern", "")).strip()
+                if not pattern:
+                    continue
+                if not label:
+                    label = pattern
+                key = (label, pattern)
+                if key in seen:
+                    continue
+                seen.add(key)
+                presets_out.append({"label": label, "pattern": pattern})
+            if presets_out:
+                cfg["output_filename_formats"] = presets_out
         if self.var_csv.get():
             cfg["csv_log_path"] = self.var_csv_path.get()
         return cfg
@@ -409,6 +606,17 @@ class App(tk.Tk):
     def _on_worker_done(self):
         self.btn_run.config(state=tk.NORMAL)
         self.btn_stop.config(state=tk.DISABLED)
+
+    def _exit_app(self):
+        if self.worker_thread and self.worker_thread.is_alive():
+            should_exit = messagebox.askyesno(
+                "Verarbeitung läuft",
+                "Die Verarbeitung läuft noch. Möchten Sie die Anwendung trotzdem beenden?",
+            )
+            if not should_exit:
+                return
+            self.stop_flag.set()
+        self.destroy()
 
     # --------------------------
     # Log & Tabs


### PR DESCRIPTION
## Summary
- add five suggested output filename presets to the configuration and keep them persisted
- allow the GUI to pick an output filename preset via dropdown while keeping custom strings editable
- let the sorter fall back to the first configured preset when no explicit format is set
- display a right-aligned tool info panel describing PDF Rechnungs Changer, its author, and the open source usage disclaimer

## Testing
- python -m compileall gui_app.py sorter.py

------
https://chatgpt.com/codex/tasks/task_e_68d0ef3f8d108327a4298f0886de8512