### PR TITLE
Add quick access button for inbox folder

### DIFF
--- a/gui_app.py
+++ b/gui_app.py
@@ -396,10 +396,12 @@ class App(tk.Tk):
         self.btn_save = ttk.Button(actions, text="Konfig speichern", command=self._save_config)
         self.btn_run = ttk.Button(actions, text="Verarbeiten starten", command=self._run_worker)
         self.btn_stop = ttk.Button(actions, text="Stop", command=self._stop_worker, state=tk.DISABLED)
+        self.btn_open_inbox = ttk.Button(actions, text="Ordner öffnen", command=self._open_inbox)
         self.btn_preview = ttk.Button(actions, text="Vorschau laden…", command=self._preview_any_pdf)
         self.btn_save.pack(side=tk.LEFT)
         self.btn_run.pack(side=tk.LEFT, padx=8)
         self.btn_stop.pack(side=tk.LEFT)
+        self.btn_open_inbox.pack(side=tk.LEFT, padx=(12, 0))
         self.btn_preview.pack(side=tk.RIGHT)
         # Notebook mit Tabs: Log, Vorschau, Fehler, Regex-Tester
         nb = ttk.Notebook(root)
@@ -482,6 +484,38 @@ class App(tk.Tk):
                                        filetypes=[("YAML", "*.yaml;*.yml"), ("Alle Dateien", "*.*")])
         if f:
             self.var_patterns_path.set(f)
+
+    def _open_inbox(self):
+        path_value = (self.var_input.get() or "").strip()
+        if not path_value:
+            messagebox.showinfo("Hinweis", "Bitte zuerst einen Eingangsordner konfigurieren.")
+            return
+
+        folder = Path(path_value).expanduser()
+        if not folder.is_absolute():
+            folder = Path.cwd() / folder
+
+        try:
+            folder.mkdir(parents=True, exist_ok=True)
+        except Exception as exc:
+            messagebox.showerror("Fehler", f"Eingangsordner konnte nicht erstellt werden: {exc}")
+            return
+
+        folder_str = str(folder.resolve())
+
+        try:
+            if sys.platform.startswith("win"):
+                os.startfile(folder_str)
+                result_code = 0
+            else:
+                cmd = ["open", folder_str] if sys.platform == "darwin" else ["xdg-open", folder_str]
+                completed = subprocess.run(cmd, check=False)
+                result_code = completed.returncode
+            if result_code not in (0, None):
+                raise RuntimeError(f"Rückgabecode {result_code}")
+            self._log("INFO", f"Eingangsordner geöffnet: {folder_str}\n")
+        except Exception as exc:
+            messagebox.showerror("Fehler", f"Ordner konnte nicht geöffnet werden: {exc}")
     # --------------------------
     # Tesseract-Sprachen ermitteln
     # --------------------------


### PR DESCRIPTION
## Summary
- add an "Ordner öffnen" button to the GUI action bar for quick access to the inbox directory
- implement cross-platform handler that ensures the inbox folder exists and opens it in the system file explorer while logging the action

## Testing
- python -m compileall gui_app.py

------
https://chatgpt.com/codex/tasks/task_e_68d28151c0088327b44be83975fd4a9b