### PR TITLE
Improve GUI fallback metadata population

### DIFF
--- a/gui_app.py
+++ b/gui_app.py
@@ -85,10 +85,41 @@ def _normalize_analysis(data) -> dict:
 
 
 def _fallback_process_all(cfg_like, patterns_path, stop_fn=None, progress_fn=None, log_csv_path=None):
+    cfg_like = cfg_like or {}
     input_dir = Path(cfg_like.get("input_dir") or "inbox")
     output_dir = Path(cfg_like.get("output_dir") or "processed")
     unknown_dir_name = cfg_like.get("unknown_dir_name") or "unbekannt"
     dry_run = bool(cfg_like.get("dry_run", False))
+
+    def _load_patterns_once(path_like):
+        patterns_dict = {}
+        if sorter and hasattr(sorter, "load_patterns"):
+            try:
+                loaded = sorter.load_patterns(path_like)
+                if isinstance(loaded, dict):
+                    patterns_dict = dict(loaded)
+            except Exception as exc:  # pragma: no cover - GUI fallback logging
+                print(f"[Fallback] Konnte Muster nicht laden: {exc}", file=sys.stderr)
+        if not patterns_dict and path_like:
+            try:
+                raw = yaml.safe_load(Path(path_like).read_text(encoding="utf-8"))
+                if isinstance(raw, dict):
+                    patterns_dict = dict(raw)
+            except FileNotFoundError:
+                pass
+            except Exception as exc:  # pragma: no cover - GUI fallback logging
+                print(f"[Fallback] Muster-Datei konnte nicht gelesen werden: {exc}", file=sys.stderr)
+        return patterns_dict
+
+    patterns_dict = _load_patterns_once(patterns_path)
+    invoice_patterns = list(patterns_dict.get("invoice_number_patterns") or [])
+    date_patterns = list(patterns_dict.get("date_patterns") or [])
+    supplier_hints = patterns_dict.get("supplier_hints") or {}
+
+    use_ocr = bool(cfg_like.get("use_ocr", True))
+    poppler_path = cfg_like.get("poppler_path") or ""
+    tesseract_cmd = cfg_like.get("tesseract_cmd") or ""
+    tesseract_lang = cfg_like.get("tesseract_lang") or "deu+eng"
 
     input_dir.mkdir(parents=True, exist_ok=True)
     output_dir.mkdir(parents=True, exist_ok=True)
@@ -120,6 +151,48 @@ def _fallback_process_all(cfg_like, patterns_path, stop_fn=None, progress_fn=Non
     total = len(files)
     print(f"[Fallback] {total} PDF-Datei(en) in {input_dir} gefunden.")
 
+    def _manual_analyze(pdf_path: Path):
+        data = {"source": str(pdf_path)}
+        text = ""
+        method = "unavailable"
+        if sorter and hasattr(sorter, "extract_text_from_pdf"):
+            try:
+                text, method = sorter.extract_text_from_pdf(
+                    str(pdf_path),
+                    use_ocr=use_ocr,
+                    poppler_path=poppler_path or None,
+                    tesseract_cmd=tesseract_cmd or None,
+                    tesseract_lang=tesseract_lang or "deu+eng",
+                )
+            except Exception as exc:  # pragma: no cover - GUI fallback logging
+                method = "error"
+                data.setdefault("error", str(exc))
+        data.setdefault("text_method", method)
+        data.setdefault("text_length", len(text))
+        if text:
+            if sorter and hasattr(sorter, "extract_invoice_no"):
+                try:
+                    data["invoice_no"] = sorter.extract_invoice_no(text, invoice_patterns)
+                except Exception as exc:  # pragma: no cover - GUI fallback logging
+                    data.setdefault("error", str(exc))
+                    data.setdefault("invoice_no", None)
+            if sorter and hasattr(sorter, "extract_date"):
+                try:
+                    data["invoice_date"] = sorter.extract_date(text, date_patterns)
+                except Exception as exc:  # pragma: no cover - GUI fallback logging
+                    data.setdefault("error", str(exc))
+                    data.setdefault("invoice_date", None)
+            if sorter and hasattr(sorter, "detect_supplier"):
+                try:
+                    data["supplier"] = sorter.detect_supplier(text, supplier_hints)
+                except Exception as exc:  # pragma: no cover - GUI fallback logging
+                    data.setdefault("error", str(exc))
+                    data.setdefault("supplier", None)
+        data.setdefault("invoice_no", None)
+        data.setdefault("invoice_date", None)
+        data.setdefault("supplier", None)
+        return data
+
     try:
         for idx, pdf in enumerate(files, start=1):
             if stop_fn and stop_fn():
@@ -132,8 +205,8 @@ def _fallback_process_all(cfg_like, patterns_path, stop_fn=None, progress_fn=Non
                     analysis_dict = _normalize_analysis(
                         sorter.analyze_pdf(
                             str(pdf),
-                            patterns_path=patterns_path,
                             config=cfg_like,
+                            patterns=patterns_dict,
                         )
                     )
                 else:
@@ -145,7 +218,25 @@ def _fallback_process_all(cfg_like, patterns_path, stop_fn=None, progress_fn=Non
                 )
                 analysis_dict = {"error": str(exc), "validation_status": "fail"}
 
-            supplier_value = analysis_dict.get("supplier") or unknown_dir_name
+            if not analysis_dict:
+                manual = _manual_analyze(pdf)
+                analysis_dict = manual
+            else:
+                if (not analysis_dict.get("invoice_no")) and (not analysis_dict.get("invoice_date")) and (
+                    not analysis_dict.get("supplier")
+                ):
+                    manual = _manual_analyze(pdf)
+                    for key, value in manual.items():
+                        if key not in analysis_dict or not analysis_dict.get(key):
+                            analysis_dict[key] = value
+
+            analysis_dict.setdefault("text_method", "unavailable")
+            analysis_dict.setdefault("text_length", 0)
+            analysis_dict.setdefault("source", str(pdf))
+
+            raw_supplier = analysis_dict.get("supplier")
+            supplier_value = raw_supplier if raw_supplier else unknown_dir_name
+            supplier_value = str(supplier_value)
             supplier_folder = _sanitize_folder_name(supplier_value) or unknown_dir_name
             target_dir = output_dir / supplier_folder
             target_dir.mkdir(parents=True, exist_ok=True)
@@ -170,13 +261,35 @@ def _fallback_process_all(cfg_like, patterns_path, stop_fn=None, progress_fn=Non
                         file=sys.stderr,
                     )
 
-            if not status:
-                status = "fail" if move_failed else "ok"
+            invoice_no_val = analysis_dict.get("invoice_no")
+            invoice_date_val = analysis_dict.get("invoice_date")
+            supplier_known = bool(raw_supplier) and str(raw_supplier).lower() != str(unknown_dir_name).lower()
+
+            if move_failed:
+                status = "fail"
+            else:
+                if not status:
+                    if invoice_no_val and invoice_date_val and supplier_known:
+                        status = "ok"
+                    else:
+                        status = "needs_review"
+            analysis_dict["supplier"] = supplier_value
 
             analysis_dict.setdefault("invoice_no", None)
             analysis_dict.setdefault("invoice_date", None)
-            analysis_dict["supplier"] = supplier_value
             analysis_dict["validation_status"] = status
+            analysis_dict["status"] = status
+            analysis_dict.setdefault("destination", moved_path)
+            analysis_dict.setdefault("target_path", moved_path)
+            analysis_dict.setdefault("target", moved_path)
+            analysis_dict.setdefault("output_path", moved_path)
+            analysis_dict.setdefault("dest", moved_path)
+            analysis_dict.setdefault("destination_path", moved_path)
+            analysis_dict.setdefault("resolved_path", moved_path)
+            analysis_dict.setdefault("moved_path", moved_path)
+            analysis_dict.setdefault("original_filename", pdf.name)
+            analysis_dict["simulate"] = dry_run
+            analysis_dict["moved"] = not move_failed and not dry_run
 
             data_ns = SimpleNamespace(**analysis_dict)
             if progress_fn:

--- a/sorter.py
+++ b/sorter.py
@@ -1,1 +1,570 @@
-def analyze_pdf(x,*a,**k): return {'source':x}
+from __future__ import annotations
+
+import csv
+import os
+import re
+import shutil
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Callable, Dict, List, Mapping, Optional, Sequence, Tuple, Union
+
+try:
+    import yaml  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    yaml = None  # type: ignore
+
+PathLike = Union[str, os.PathLike[str]]
+
+DEFAULT_CONFIG: Dict[str, Union[str, bool]] = {
+    "input_dir": "inbox",
+    "output_dir": "processed",
+    "unknown_dir_name": "unbekannt",
+    "tesseract_cmd": "",
+    "poppler_path": "",
+    "tesseract_lang": "deu+eng",
+    "use_ocr": True,
+    "dry_run": False,
+    "csv_log_path": "",
+    "output_filename_format": "{date}_{supplier}_{invoice_no}.pdf",
+}
+
+DEFAULT_PATTERNS: Dict[str, object] = {
+    "invoice_number_patterns": [],
+    "date_patterns": [],
+    "supplier_hints": {},
+}
+
+
+@dataclass
+class ExtractionResult:
+    text: str
+    method: str
+    page_count: int
+
+
+def _read_yaml(path: PathLike) -> Dict[str, object]:
+    if yaml is None:
+        raise RuntimeError("PyYAML ist nicht installiert – config/patterns können nicht gelesen werden.")
+    with open(Path(path), "r", encoding="utf-8") as handle:
+        data = yaml.safe_load(handle) or {}
+    if isinstance(data, dict):
+        return dict(data)
+    raise ValueError(f"YAML-Datei {path} muss ein Mapping enthalten.")
+
+
+def load_config(config_like: Union[None, PathLike, Mapping[str, object]]) -> Dict[str, object]:
+    """Lädt die Konfiguration aus Datei oder Mapping und mischt sie mit Defaults."""
+
+    cfg: Dict[str, object] = dict(DEFAULT_CONFIG)
+    if config_like is None:
+        return cfg
+    data: Mapping[str, object]
+    if isinstance(config_like, (str, os.PathLike)):
+        data = _read_yaml(config_like)
+    elif isinstance(config_like, Mapping):
+        data = config_like
+    else:  # pragma: no cover - defensive
+        raise TypeError("config_like muss Pfad oder Mapping sein")
+    for key, value in data.items():
+        if value is None:
+            continue
+        cfg[key] = value
+    # Strings bereinigen
+    for key in ("tesseract_cmd", "poppler_path", "unknown_dir_name", "csv_log_path", "output_filename_format"):
+        if key in cfg and isinstance(cfg[key], str):
+            cfg[key] = cfg[key].strip()
+    return cfg
+
+
+def load_patterns(patterns_like: Union[None, PathLike, Mapping[str, object]]) -> Dict[str, object]:
+    pats: Dict[str, object] = dict(DEFAULT_PATTERNS)
+    if patterns_like is None:
+        return pats
+    data: Mapping[str, object]
+    if isinstance(patterns_like, (str, os.PathLike)):
+        data = _read_yaml(patterns_like)
+    elif isinstance(patterns_like, Mapping):
+        data = patterns_like
+    else:  # pragma: no cover - defensive
+        raise TypeError("patterns_like muss Pfad oder Mapping sein")
+    for key, value in data.items():
+        if value is None:
+            continue
+        pats[key] = value
+    return pats
+
+
+def _sanitize_component(value: Optional[str]) -> str:
+    if not value:
+        return ""
+    text = str(value).strip()
+    if not text:
+        return ""
+    text = re.sub(r"\s+", " ", text)
+    table = str.maketrans({c: "_" for c in '<>:"/\\|?*'})
+    text = text.translate(table)
+    text = text.strip(" ._")
+    return text
+
+
+def _ensure_filename(name: str) -> str:
+    name = name.strip()
+    if not name:
+        return "document.pdf"
+    if not name.lower().endswith(".pdf"):
+        name += ".pdf"
+    name = re.sub(r"[\\/:*?\"<>|]", "_", name)
+    name = name.strip(" .")
+    return name or "document.pdf"
+
+
+def _unique_path(directory: Path, filename: str) -> Path:
+    candidate = directory / filename
+    if not candidate.exists():
+        return candidate
+    stem, ext = os.path.splitext(filename)
+    counter = 1
+    while True:
+        alt = directory / f"{stem}_{counter}{ext or '.pdf'}"
+        if not alt.exists():
+            return alt
+        counter += 1
+
+
+def _extract_with_pymupdf(pdf_path: Path) -> ExtractionResult:
+    try:
+        import fitz  # type: ignore
+    except Exception:  # pragma: no cover - optional dependency
+        return ExtractionResult(text="", method="unavailable", page_count=0)
+    text_parts: List[str] = []
+    page_count = 0
+    try:
+        with fitz.open(str(pdf_path)) as doc:  # type: ignore[attr-defined]
+            page_count = doc.page_count
+            for page in doc:  # type: ignore[assignment]
+                text_parts.append(page.get_text("text") or "")
+    except Exception:
+        return ExtractionResult(text="", method="error", page_count=page_count)
+    text = "\n".join(text_parts)
+    return ExtractionResult(text=text, method="text", page_count=page_count)
+
+
+def _extract_with_pypdf2(pdf_path: Path) -> ExtractionResult:
+    try:
+        from PyPDF2 import PdfReader  # type: ignore
+    except Exception:  # pragma: no cover - optional dependency
+        return ExtractionResult(text="", method="unavailable", page_count=0)
+    text_parts: List[str] = []
+    try:
+        reader = PdfReader(str(pdf_path))
+        page_count = len(reader.pages)
+        for page in reader.pages:
+            try:
+                text_parts.append(page.extract_text() or "")
+            except Exception:
+                text_parts.append("")
+    except Exception:
+        return ExtractionResult(text="", method="error", page_count=0)
+    text = "\n".join(text_parts)
+    return ExtractionResult(text=text, method="text", page_count=len(text_parts))
+
+
+def _extract_with_ocr(
+    pdf_path: Path,
+    poppler_path: Optional[str],
+    tesseract_cmd: Optional[str],
+    tesseract_lang: str,
+    max_pages: int = 5,
+) -> ExtractionResult:
+    try:
+        from pdf2image import convert_from_path  # type: ignore
+    except Exception:  # pragma: no cover - optional dependency
+        return ExtractionResult(text="", method="unavailable", page_count=0)
+    try:
+        import pytesseract  # type: ignore
+    except Exception:  # pragma: no cover - optional dependency
+        return ExtractionResult(text="", method="unavailable", page_count=0)
+
+    if tesseract_cmd:
+        try:
+            pytesseract.pytesseract.tesseract_cmd = tesseract_cmd
+        except Exception:
+            pass
+    lang = tesseract_lang or "deu+eng"
+    try:
+        images = convert_from_path(
+            str(pdf_path),
+            dpi=300,
+            poppler_path=poppler_path or None,
+            first_page=1,
+            last_page=max_pages,
+        )
+    except Exception:
+        return ExtractionResult(text="", method="error", page_count=0)
+    text_parts: List[str] = []
+    for image in images:
+        try:
+            text_parts.append(pytesseract.image_to_string(image, lang=lang) or "")
+        except Exception:
+            text_parts.append("")
+    text = "\n".join(text_parts)
+    return ExtractionResult(text=text, method="ocr", page_count=len(images))
+
+
+def extract_text_from_pdf(
+    pdf_path: PathLike,
+    *,
+    use_ocr: bool = True,
+    poppler_path: Optional[str] = None,
+    tesseract_cmd: Optional[str] = None,
+    tesseract_lang: str = "deu+eng",
+    min_text_length: int = 50,
+) -> Tuple[str, str]:
+    """Extrahiert Text aus einer PDF-Datei und nutzt optional OCR als Fallback."""
+
+    path = Path(pdf_path)
+    if not path.exists():
+        raise FileNotFoundError(f"PDF nicht gefunden: {path}")
+
+    result = _extract_with_pymupdf(path)
+    text = result.text
+    method = result.method
+
+    if not text.strip():
+        alt = _extract_with_pypdf2(path)
+        if alt.text.strip():
+            text = alt.text
+            method = alt.method
+
+    if use_ocr and len(text.strip()) < min_text_length:
+        ocr_res = _extract_with_ocr(path, poppler_path, tesseract_cmd, tesseract_lang)
+        if ocr_res.text.strip():
+            text = ocr_res.text
+            method = ocr_res.method
+
+    return text, method
+
+
+def extract_invoice_no(text: str, patterns: Sequence[str]) -> Optional[str]:
+    if not text:
+        return None
+    for pattern in patterns:
+        try:
+            regex = re.compile(pattern, re.IGNORECASE)
+        except re.error:
+            continue
+        match = regex.search(text)
+        if match:
+            groups = [g for g in match.groups() if g]
+            value = groups[0] if groups else match.group(0)
+            if value:
+                cleaned = re.sub(r"[^A-Z0-9\-_/]+", "", value.upper())
+                return cleaned or value.strip()
+    return None
+
+
+def _normalize_date_candidate(candidate: str) -> Optional[str]:
+    candidate = candidate.strip()
+    if not candidate:
+        return None
+    candidate = candidate.replace("\\", ".")
+    candidate = re.sub(r"[\s]+", "", candidate)
+    formats = [
+        "%d.%m.%Y",
+        "%d.%m.%y",
+        "%Y-%m-%d",
+        "%d-%m-%Y",
+        "%d-%m-%y",
+        "%Y/%m/%d",
+        "%d/%m/%Y",
+        "%d/%m/%y",
+        "%Y.%m.%d",
+        "%Y%m%d",
+        "%d%m%Y",
+    ]
+    for fmt in formats:
+        try:
+            dt = datetime.strptime(candidate, fmt)
+            if dt.year < 1900 or dt.year > 2100:
+                continue
+            return dt.strftime("%Y-%m-%d")
+        except ValueError:
+            continue
+    # Heuristik: ersetze verschiedene Trenner mit '-'
+    cleaned = re.sub(r"[./]", "-", candidate)
+    parts = cleaned.split("-")
+    if len(parts) == 3:
+        a, b, c = parts
+        try:
+            if len(a) == 4:
+                dt = datetime(int(a), int(b), int(c))
+            elif len(c) == 4:
+                dt = datetime(int(c), int(b), int(a))
+            else:
+                dt = datetime(int(c), int(b), int(a))
+            if 1900 <= dt.year <= 2100:
+                return dt.strftime("%Y-%m-%d")
+        except ValueError:
+            return None
+    return None
+
+
+def extract_date(text: str, patterns: Sequence[str]) -> Optional[str]:
+    if not text:
+        return None
+    for pattern in patterns:
+        try:
+            regex = re.compile(pattern, re.IGNORECASE)
+        except re.error:
+            continue
+        for match in regex.finditer(text):
+            groups = [g for g in match.groups() if g]
+            candidate = groups[0] if groups else match.group(0)
+            norm = _normalize_date_candidate(candidate)
+            if norm:
+                return norm
+    return None
+
+
+def detect_supplier(text: str, hints: Mapping[str, Sequence[str]]) -> Optional[str]:
+    if not text or not hints:
+        return None
+    lower = text.lower()
+    best_supplier = None
+    best_score = 0
+    for supplier, keywords in hints.items():
+        score = 0
+        for keyword in keywords or []:
+            if not keyword:
+                continue
+            if keyword.lower() in lower:
+                score += 1
+        if score > best_score:
+            best_supplier = supplier
+            best_score = score
+    return best_supplier
+
+
+def analyze_pdf(
+    pdf_path: PathLike,
+    *,
+    patterns_path: Optional[PathLike] = None,
+    config: Optional[Mapping[str, object]] = None,
+    patterns: Optional[Mapping[str, object]] = None,
+) -> Dict[str, object]:
+    cfg = load_config(config)
+    pats = load_patterns(patterns if patterns is not None else patterns_path)
+    text, method = extract_text_from_pdf(
+        pdf_path,
+        use_ocr=bool(cfg.get("use_ocr", True)),
+        poppler_path=str(cfg.get("poppler_path") or "") or None,
+        tesseract_cmd=str(cfg.get("tesseract_cmd") or "") or None,
+        tesseract_lang=str(cfg.get("tesseract_lang") or "deu+eng"),
+    )
+    invoice_no = extract_invoice_no(text, pats.get("invoice_number_patterns", []) or [])
+    invoice_date = extract_date(text, pats.get("date_patterns", []) or [])
+    supplier = detect_supplier(text, pats.get("supplier_hints", {}) or {})
+
+    unknown_dir_name = str(cfg.get("unknown_dir_name") or DEFAULT_CONFIG["unknown_dir_name"])
+    supplier_value = supplier or unknown_dir_name
+
+    validation_status = "ok" if (invoice_no and invoice_date and supplier) else "needs_review"
+    result: Dict[str, object] = {
+        "source": str(pdf_path),
+        "invoice_no": invoice_no,
+        "invoice_date": invoice_date,
+        "supplier": supplier_value,
+        "text_method": method,
+        "text_length": len(text),
+        "validation_status": validation_status,
+    }
+    return result
+
+
+def process_pdf(
+    pdf_path: PathLike,
+    *,
+    config_path: Optional[PathLike] = None,
+    patterns_path: Optional[PathLike] = None,
+    config: Optional[Mapping[str, object]] = None,
+    patterns: Optional[Mapping[str, object]] = None,
+    simulate: Optional[bool] = None,
+) -> Dict[str, object]:
+    path = Path(pdf_path)
+    if not path.exists():
+        raise FileNotFoundError(f"PDF nicht gefunden: {path}")
+
+    cfg = load_config(config if config is not None else config_path)
+    pats = load_patterns(patterns if patterns is not None else patterns_path)
+
+    analysis = analyze_pdf(path, config=cfg, patterns=pats)
+
+    unknown_dir_name = str(cfg.get("unknown_dir_name") or DEFAULT_CONFIG["unknown_dir_name"])
+    output_dir = Path(str(cfg.get("output_dir") or DEFAULT_CONFIG["output_dir"]))
+
+    supplier_folder = _sanitize_component(analysis.get("supplier", "")) or _sanitize_component(unknown_dir_name) or "unbekannt"
+    target_dir = output_dir / supplier_folder
+
+    date_value = analysis.get("invoice_date") or datetime.now().strftime("%Y-%m-%d")
+    supplier_value = supplier_folder
+    invoice_no = analysis.get("invoice_no") or ""
+
+    fmt = str(cfg.get("output_filename_format") or DEFAULT_CONFIG["output_filename_format"])
+    values = {
+        "date": date_value,
+        "supplier": supplier_value,
+        "invoice_no": invoice_no,
+        "original_name": path.stem,
+    }
+    try:
+        filename = fmt.format(**values)
+    except KeyError:
+        fallback_fmt = DEFAULT_CONFIG["output_filename_format"]
+        filename = str(fallback_fmt).format(**values)
+    filename = _ensure_filename(filename)
+
+    target_path = _unique_path(target_dir, filename)
+
+    effective_simulate = simulate if simulate is not None else bool(cfg.get("dry_run", False))
+    moved = False
+    if not effective_simulate:
+        target_path.parent.mkdir(parents=True, exist_ok=True)
+        shutil.move(str(path), str(target_path))
+        moved = True
+
+    result = dict(analysis)
+    result.update(
+        {
+            "target": str(target_path),
+            "destination": str(target_path),
+            "output_path": str(target_path),
+            "dest": str(target_path),
+            "target_path": str(target_path),
+            "destination_path": str(target_path),
+            "resolved_path": str(target_path),
+            "moved_path": str(target_path),
+            "status": result.get("validation_status"),
+            "simulate": effective_simulate,
+            "moved": moved,
+            "original_filename": path.name,
+            "supplier": supplier_value,
+        }
+    )
+    return result
+
+
+def process_all(
+    config_path: Optional[PathLike] = None,
+    patterns_path: Optional[PathLike] = None,
+    *,
+    stop_fn: Optional[Callable[[], bool]] = None,
+    progress_fn: Optional[Callable[[int, int, str, object], None]] = None,
+    log_csv_path: Optional[PathLike] = None,
+    config: Optional[Mapping[str, object]] = None,
+    patterns: Optional[Mapping[str, object]] = None,
+    simulate: Optional[bool] = None,
+) -> None:
+    cfg = load_config(config if config is not None else config_path)
+    pats = load_patterns(patterns if patterns is not None else patterns_path)
+
+    input_dir = Path(str(cfg.get("input_dir") or DEFAULT_CONFIG["input_dir"]))
+    output_dir = Path(str(cfg.get("output_dir") or DEFAULT_CONFIG["output_dir"]))
+    unknown_dir_name = str(cfg.get("unknown_dir_name") or DEFAULT_CONFIG["unknown_dir_name"])
+    unknown_dir = output_dir / (_sanitize_component(unknown_dir_name) or "unbekannt")
+
+    input_dir.mkdir(parents=True, exist_ok=True)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    unknown_dir.mkdir(parents=True, exist_ok=True)
+
+    effective_simulate = simulate if simulate is not None else bool(cfg.get("dry_run", False))
+
+    files = sorted(p for p in input_dir.glob("*.pdf") if p.is_file())
+    total = len(files)
+
+    csv_path = Path(str(log_csv_path or cfg.get("csv_log_path") or "")).expanduser()
+    csv_file = None
+    csv_writer = None
+    if csv_path and csv_path.name:
+        csv_path.parent.mkdir(parents=True, exist_ok=True)
+        csv_file = csv_path.open("a", encoding="utf-8", newline="")
+        csv_writer = csv.writer(csv_file, delimiter=";")
+        if csv_path.stat().st_size == 0:
+            csv_writer.writerow(
+                [
+                    "timestamp",
+                    "source",
+                    "destination",
+                    "invoice_no",
+                    "supplier",
+                    "invoice_date",
+                    "status",
+                ]
+            )
+            csv_file.flush()
+
+    try:
+        for idx, pdf in enumerate(files, start=1):
+            if stop_fn and stop_fn():
+                break
+            try:
+                result = process_pdf(
+                    pdf,
+                    config=cfg,
+                    patterns=pats,
+                    simulate=effective_simulate,
+                )
+            except Exception as exc:
+                target_path = unknown_dir / pdf.name
+                if not effective_simulate:
+                    target_path.parent.mkdir(parents=True, exist_ok=True)
+                    try:
+                        shutil.move(str(pdf), str(target_path))
+                    except Exception:
+                        target_path = pdf
+                result = {
+                    "source": str(pdf),
+                    "invoice_no": None,
+                    "invoice_date": None,
+                    "supplier": unknown_dir_name,
+                    "validation_status": "fail",
+                    "status": "fail",
+                    "target_path": str(target_path),
+                    "destination": str(target_path),
+                    "error": str(exc),
+                }
+            if progress_fn:
+                try:
+                    progress_fn(idx, total, str(pdf), SimpleNamespace(**result))
+                except Exception:
+                    pass
+            if csv_writer:
+                csv_writer.writerow(
+                    [
+                        datetime.now().isoformat(timespec="seconds"),
+                        str(pdf),
+                        result.get("destination") or result.get("target_path"),
+                        result.get("invoice_no"),
+                        result.get("supplier"),
+                        result.get("invoice_date"),
+                        result.get("validation_status") or result.get("status"),
+                    ]
+                )
+                csv_file.flush()
+    finally:
+        if csv_file:
+            csv_file.close()
+
+
+__all__ = [
+    "load_config",
+    "load_patterns",
+    "extract_text_from_pdf",
+    "extract_invoice_no",
+    "extract_date",
+    "detect_supplier",
+    "analyze_pdf",
+    "process_pdf",
+    "process_all",
+]


### PR DESCRIPTION
## Summary
- add full featured sorter module with config/pattern loaders and OCR-capable text extraction
- implement invoice number, date, and supplier detection helpers for GUI preview and regex tester
- provide analyze, process_pdf, and process_all functions to drive file moves and CSV logging
- extend the GUI fallback workflow to load patterns once, reuse extraction helpers, and emit supplier, invoice number, date, and validation status metadata when sorter.process_all is unavailable

## Testing
- `python -m compileall gui_app.py sorter.py`
- `python debug_import_sorter.py`


------
https://chatgpt.com/codex/tasks/task_e_68d293799c488327a49fd10db1797d5b