### PR TITLE
Add output filename format presets to GUI

### DIFF
--- a/docs/benutzerhandbuch.md
+++ b/docs/benutzerhandbuch.md
@@ -1,0 +1,314 @@
+# Benutzerhandbuch – PDF Rechnung Changer
+
+Version: CLEAN_START_v2 • Plattform: Windows, Linux, macOS
+
+---
+
+## 1. Zweck und Funktionsumfang
+
+**PDF Rechnung Changer** ist ein lokales Werkzeug zum **Analysieren**, **Benennen** und **Verschieben** von PDF‑Rechnungen. Es bietet eine grafische Oberfläche (GUI), optionalen **Hotfolder‑Betrieb** und **OCR** (Texterkennung) über Tesseract + Poppler, falls ein PDF kaum eingebetteten Text enthält.
+
+Kernfunktionen:
+- Extraktion von Rechnungsdaten (Rechnungsnummer, Datum, Lieferant; optional Betrag, IBAN)
+- Automatisches Umbenennen gemäß Muster (z. B. `{date}_{supplier}_{invoice_no}.pdf`)
+- Fallback in einen „Unbekannt“-Ordner, wenn Pflichtfelder fehlen
+- CSV‑Protokollierung (optional)
+- Hotfolder‑Modus für unbeaufsichtigtes Verarbeiten
+- Diagnose: Systemcheck, Sorter‑Diagnose, Systeminfo kopieren
+
+---
+
+## 2. Systemvoraussetzungen
+
+- **Python** 3.x
+- Python‑Pakete: `pyyaml`, `pymupdf`, `PyPDF2`, `pdf2image`, `pytesseract`, `pillow`  
+  (installierbar via `requirements.txt`)
+- **Tesseract OCR** (Binary `tesseract`)
+- **Poppler** (Tools `pdftoppm`/`pdftocairo` für `pdf2image`)
+
+> Hinweis: Der Systemcheck (Menü **Hilfe → Systemcheck**) prüft alle Abhängigkeiten und zeigt gefundene Versionen und Pfade.
+
+---
+
+## 3. Installation und Schnellstart
+
+### 3.1 Windows (empfohlen mit Startskript)
+1. ZIP `PDF-Wandler_CLEAN_START_v2.zip` entpacken.
+2. `start_gui.bat` ausführen.  
+   Das Skript erstellt (falls nötig) eine virtuelle Umgebung, installiert Abhängigkeiten und startet die GUI.
+3. Optional: `start_hotfolder.bat` für den Hotfolder‑Betrieb.
+
+### 3.2 Linux/macOS
+```bash
+chmod +x start_gui.sh start_hotfolder.sh
+./start_gui.sh          # GUI
+# oder
+./start_hotfolder.sh    # Hotfolder
+```
+
+### 3.3 Manuelle Installation
+```bash
+python -m venv .venv
+# Windows: .\.venv\Scripts\Activate.ps1
+# macOS/Linux:
+source .venv/bin/activate
+
+python -m pip install --upgrade pip
+pip install -r requirements.txt
+python gui_app.py
+```
+
+---
+
+## 4. Erstinbetriebnahme
+
+1. Beim ersten Start legt die Anwendung automatisch folgende Ordner an (falls nicht vorhanden):  
+   `inbox/`, `processed/`, `processed/unbekannt/`, `error/`, `logs/`.
+2. Öffnen Sie **Hilfe → Systemcheck**. Prüfen Sie, ob
+   - Python‑Module vorhanden sind,
+   - **Tesseract** gefunden wird (Version),
+   - **Poppler** (`pdftoppm`/`pdftocairo`) erkannt wird.
+3. Tragen Sie ggf. in der GUI oder in `config.yaml` die Pfade ein:
+   - `tesseract_cmd` (Pfad zur `tesseract`‑Binary)
+   - `poppler_path` (Ordner, der `pdftoppm`/`pdftocairo` enthält)
+4. Speichern Sie die Konfiguration (**Strg+S**).
+
+---
+
+## 5. Bedienoberfläche
+
+### 5.1 Hauptfenster
+- **Eingang**: Ordner mit zu verarbeitenden PDFs (Standard: `inbox/`)
+- **Ausgang**: Zielordner (Standard: `processed/`)
+- **Optionen**:
+  - OCR verwenden (empfohlen)
+  - Dry‑Run (Simulation ohne Schreibzugriffe)
+  - CSV aktiv + Pfad (z. B. `logs/processed.csv`)
+- **Buttons**:
+  - **Verarbeiten starten** (Strg+R)
+  - **Stop** (Esc)
+  - **Info** (F1)
+  - **Beenden** (Strg+Q)
+- **Logfenster**: Laufende Protokoll‑ und Statusmeldungen
+
+### 5.2 Menü
+- **Datei**
+  - *Konfig öffnen…* (Strg+O)
+  - *Konfig speichern* (Strg+S)
+  - *Verarbeiten starten* (Strg+R)
+  - *Stop* (Esc)
+  - *Beenden* (Strg+Q)
+- **Hilfe**
+  - *Systemcheck*
+  - *Systeminfo kopieren*
+  - *Sorter‑Diagnose*
+  - *Info* (F1)
+
+### 5.3 Tastenkürzel
+- Strg+S / Strg+O / Strg+R / Strg+Q, Esc, F1  
+- macOS: ⌘S / ⌘O / ⌘R / ⌘Q
+
+---
+
+## 6. Typischer Arbeitsablauf (GUI)
+
+1. **Eingang/Ausgang** prüfen oder setzen.
+2. **Patterns** in `patterns.yaml` ggf. anpassen (siehe Kapitel 8).
+3. **Verarbeiten starten**. Im Log erscheinen Zeilen wie:
+   - `[i/total] <Datei> -> ok` (vollständig erkannt) oder `needs_review` (unvollständig).
+4. Ergebnis:
+   - Umbenannte Dateien landen in `processed/`.
+   - Unvollständige Dateien landen in `processed/unbekannt/`.
+5. Optional: CSV‑Log prüfen (`logs/processed.csv`).
+
+---
+
+## 7. Konfiguration (`config.yaml`)
+
+Beispielfile (mitgeliefert):
+```yaml
+input_dir: inbox
+output_dir: processed
+unknown_dir_name: unbekannt
+tesseract_cmd: ""           # Pfad zu 'tesseract' oder leer, wenn im PATH
+poppler_path: ""            # Pfad zu Poppler 'bin' oder leer, wenn im PATH
+tesseract_lang: "deu+eng"   # OCR-Sprachen
+use_ocr: true               # OCR aktivieren, wenn PDF wenig/keinen Text hat
+dry_run: false              # nur simulieren (keine Dateien verschieben/umbenennen)
+csv_log_path: "logs/processed.csv"
+output_filename_format: "{date}_{supplier}_{invoice_no}.pdf"
+```
+
+Parameter:
+- **input_dir** / **output_dir**: Eingangs-/Zielverzeichnis
+- **unknown_dir_name**: Unterordner in `output_dir` für unvollständige Datensätze
+- **tesseract_cmd**: Pfad zur Tesseract‑Binary
+- **poppler_path**: Ordner, der `pdftoppm`/`pdftocairo` enthält
+- **tesseract_lang**: OCR‑Sprachen (z. B. `deu`, `eng`, `deu+eng`)
+- **use_ocr**: Bei wenig/keinem eingebetteten Text automatisch OCR verwenden
+- **dry_run**: Simulation
+- **csv_log_path**: Pfad zur CSV‑Protokolldatei
+- **output_filename_format**: Muster für Zieldateinamen
+
+Platzhalter im Dateinamen‑Muster:
+- `{date}` (normalisiert: `YYYY-MM-DD`)
+- `{supplier}` (bereinigt)
+- `{invoice_no}` (bereinigt)
+
+---
+
+## 8. Mustererkennung (`patterns.yaml`)
+
+Beispiel (mitgeliefert):
+```yaml
+invoice_number_patterns:
+  - "Rechnungs(?:nummer|nr\.?)\s*[:#]?\s*([A-Z0-9\-\/]+)"
+  - "Invoice\s*(?:No\.?|Number)\s*[:#]?\s*([A-Z0-9\-\/]+)"
+  - "Beleg(?:nummer|nr\.?)\s*[:#]?\s*([A-Z0-9\-\/]+)"
+date_patterns:
+  - "(\d{1,2}[.\-/]\d{1,2}[.\-/]\d{2,4})"
+  - "(\d{4}[.\-/]\d{1,2}[.\-/]\d{1,2})"
+supplier_hints:
+  Deutsche Telekom: ["telekom", "t-mobile", "telekom deutschland"]
+  Vodafone: ["vodafone"]
+  Amazon: ["amazon services", "amazon eu", "amazon.de"]
+  REWE: ["rewe markt", "rewe"]
+  E.ON: ["e.on", "eon"]
+  IKEA: ["ikea"]
+  Deutsche Bahn: ["db fernverkehr", "deutsche bahn", "bahn.de"]
+```
+
+Hinweise:
+- Regexe bei **invoice_number_patterns** und **date_patterns** müssen **jeweils genau eine Gruppe** für den relevanten Wert liefern.
+- `supplier_hints` ist eine einfache Schlüsselwortliste pro Lieferant (case‑insensitive Vergleich).
+
+---
+
+## 9. Hotfolder‑Betrieb
+
+Start (Beispiele):
+```bash
+# Windows
+start_hotfolder.bat
+
+# Linux/macOS
+./start_hotfolder.sh
+```
+Direkt:
+```bash
+python hotfolder.py --in inbox --done processed --err error --config config.yaml --patterns patterns.yaml
+```
+Ablauf:
+- Das Skript pollt den `--in`‑Ordner.
+- Jede neue/ruhende PDF wird mit `sorter.process_pdf` verarbeitet.
+- Erfolgreiche Dateien wandern nach `--done`, fehlerhafte nach `--err`.
+
+---
+
+## 10. CSV‑Protokoll
+
+Wenn `csv_log_path` gesetzt ist, wird pro Datei protokolliert:
+```
+src;target;supplier;invoice_no;date;total;iban;status;method;ts
+```
+- **status**: `ok` oder `needs_review`
+- **method**: z. B. `pymupdf` oder `pymupdf+ocr`
+- **ts**: ISO‑Zeitstempel
+
+---
+
+## 11. Diagnosefunktionen
+
+- **Hilfe → Systemcheck**: zeigt installierte Python‑Module, Tesseract/Poppler und Pfade.
+- **Hilfe → Systeminfo kopieren**: legt die Ausgabe des Systemchecks in die Zwischenablage.
+- **Hilfe → Sorter‑Diagnose**: zeigt Pfad der geladenen `sorter.py` sowie vorhandene Funktionen (`analyze_pdf`, `process_pdf`, `process_all`, `extract_text_from_pdf`).
+
+---
+
+## 12. Qualität & OCR‑Leistung
+
+- Wählen Sie passende OCR‑Sprachen (`tesseract_lang`), z. B. `deu` oder `deu+eng`.
+- Je höher die Scan‑Qualität (DPI, Kontrast), desto zuverlässiger die Ergebnisse.
+- OCR wird nur genutzt, wenn PyMuPDF sehr wenig/keinen Text extrahieren konnte.
+
+---
+
+## 13. Fehlersuche (Troubleshooting)
+
+**Kein `yaml`‑Modul / andere Module fehlen**  
+- Installation: `pip install -r requirements.txt`  
+- Systemcheck aufrufen und Hinweise beachten.
+
+**Tesseract oder Poppler wird nicht gefunden**  
+- Pfade in `config.yaml` setzen: `tesseract_cmd`, `poppler_path`  
+- Systemcheck prüfen, ob `tesseract`, `pdftoppm`, `pdftocairo` erkannt werden.
+
+**Datei wird nicht umbenannt**  
+- Felder konnten nicht vollständig ermittelt werden. Datei wird nach `processed/unbekannt/` verschoben.  
+- `patterns.yaml` erweitern/optimieren.
+
+**Beenden reagiert nicht sofort**  
+- Zunächst **Stop** (Esc), dann **Beenden** (Strg+Q).
+
+**Hotfolder bewegt Dateien nicht**  
+- Ordnerrechte prüfen, Datei ist ggf. „gesperrt“ (noch in Kopie).  
+- Wartezeit erhöhen (`--interval`).
+
+---
+
+## 14. Best Practices
+
+- `patterns.yaml` iterativ verbessern (Begriffe der häufigsten Lieferanten ergänzen).
+- OCR‑Sprachen so schlank wie möglich halten (z. B. nur `deu`).
+- Strukturierte Zielordner wählen und `output_filename_format` an Prozess anpassen.
+- Regelmäßig CSV‑Log sichern/auswerten.
+
+---
+
+## 15. Verzeichnisstruktur (Standard)
+
+```
+/
+├─ gui_app.py
+├─ sorter.py
+├─ hotfolder.py
+├─ config.yaml
+├─ patterns.yaml
+├─ requirements.txt
+├─ README.md
+├─ start_gui.bat / start_gui.sh
+├─ start_hotfolder.bat / start_hotfolder.sh
+├─ inbox/
+├─ processed/
+│  └─ unbekannt/
+├─ error/
+└─ logs/
+```
+
+---
+
+## 16. Lizenz & Haftung
+
+- Lizenz: Opensource zur freien Verwendung
+- Haftung: ohne Gewähr; Nutzung **auf eigene Gefahr**
+
+**Autor:** Markus Dickscheit
+
+---
+
+## 17. Changelog (Auszug)
+
+**CLEAN_START_v2**  
+- OCR‑fähiger Sorter (PyMuPDF + pdf2image + pytesseract)
+- Verbesserte Start‑Guards & Ordner‑Autocreate
+- Systemcheck, Systeminfo kopieren, Sorter‑Diagnose
+- CSV‑Protokoll optional
+- Hotfolder‑Modus
+
+---
+
+## 18. Support‑Hinweise
+
+- **Systemcheck** ausführen und **Systeminfo kopieren** für Supportanfragen beilegen.
+- **Sorter‑Diagnose** ausführen und Log mit Pfad/Funktionsübersicht beilegen.
+- Ggf. Beispiel‑PDF (ohne personenbezogene Daten) und Auszüge aus `patterns.yaml` bereitstellen.

--- a/gui_app.py
+++ b/gui_app.py
@@ -357,6 +357,17 @@ class App(tk.Tk):
         self.var_inbox = tk.StringVar()
         self.var_done = tk.StringVar()
         self.var_err = tk.StringVar()
+        self.default_filename_label = "Datum_Lieferant_Rechnungsnummer.pdf"
+        self.filename_presets = [
+            (self.default_filename_label, "{date}_{supplier}_{invoice_no}.pdf"),
+            ("Lieferant_Rechnungsnummer.pdf", "{supplier}_{invoice_no}.pdf"),
+            ("Rechnungsnummer_Lieferant.pdf", "{invoice_no}_{supplier}.pdf"),
+            ("Datum_Lieferant.pdf", "{date}_{supplier}.pdf"),
+            ("Originalname.pdf", "{original_name}.pdf"),
+        ]
+        self.filename_preset_map = dict(self.filename_presets)
+        self.filename_preset_inverse = {fmt: label for label, fmt in self.filename_presets}
+        self.var_filename_pattern = tk.StringVar(value=self.default_filename_label)
         # für Fehlerliste
         self.error_rows = []  # List[dict]
         self._build_ui()
@@ -448,6 +459,30 @@ class App(tk.Tk):
         ttk.Button(row1, text="Wählen", command=self._choose_output).grid(row=1, column=2, padx=6, pady=(6,0))
         ttk.Label(row1, text="Ordner für Unbekannt:").grid(row=2, column=0, sticky=tk.W, pady=(6,0))
         ttk.Entry(row1, textvariable=self.var_unknown, width=30).grid(row=2, column=1, sticky=tk.W, pady=(6,0))
+        # Zeile 1b: Dateinamen-Format
+        row1b = ttk.Frame(cfg_frame)
+        row1b.pack(fill=tk.X, pady=6)
+        row1b.columnconfigure(1, weight=1)
+        ttk.Label(row1b, text="Dateiname-Format:").grid(row=0, column=0, sticky=tk.W)
+        self.cmb_filename_format = ttk.Combobox(
+            row1b,
+            textvariable=self.var_filename_pattern,
+            values=[label for label, _ in self.filename_presets],
+            width=40,
+            state="normal",
+        )
+        self.cmb_filename_format.grid(row=0, column=1, sticky=(tk.W, tk.E))
+        self.cmb_filename_format.bind("<<ComboboxSelected>>", lambda _e: self._update_filename_example())
+        self.var_filename_example = tk.StringVar()
+        ttk.Label(row1b, textvariable=self.var_filename_example).grid(
+            row=1, column=1, sticky=tk.W, pady=(4, 0)
+        )
+        ttk.Label(
+            row1b,
+            text="Verfügbare Platzhalter: {date}, {supplier}, {invoice_no}, {original_name}",
+        ).grid(row=2, column=1, sticky=tk.W, pady=(2, 0))
+        self.var_filename_pattern.trace_add("write", lambda *_: self._update_filename_example())
+        self._update_filename_example()
         # Zeile 2: OCR / Poppler / Tesseract / Sprache
         row2 = ttk.Frame(cfg_frame)
         row2.pack(fill=tk.X, pady=6)
@@ -581,6 +616,7 @@ class App(tk.Tk):
         help_menu = tk.Menu(menubar, tearoff=False)
         help_menu.add_command(label="Systemcheck", command=self._system_check)
         help_menu.add_command(label="Systeminfo kopieren", command=self._copy_system_info)
+        help_menu.add_command(label="Benutzerhandbuch öffnen", command=self._open_user_manual)
         help_menu.add_separator()
         help_menu.add_command(label="Sorter-Diagnose protokollieren", command=self._log_sorter_diagnostics)
         help_menu.add_command(label="Info", command=self._show_info, accelerator="F1")
@@ -619,6 +655,30 @@ class App(tk.Tk):
                                        filetypes=[("YAML", "*.yaml;*.yml"), ("Alle Dateien", "*.*")])
         if f:
             self.var_patterns_path.set(f)
+
+    def _open_user_manual(self):
+        manual_paths = [
+            Path(__file__).resolve().parent / "docs" / "benutzerhandbuch.md",
+            Path(__file__).resolve().parent / "docs" / "nutzerhandbuch.md",
+        ]
+        manual_path = next((p for p in manual_paths if p.exists()), None)
+        if not manual_path:
+            messagebox.showerror("Benutzerhandbuch", "Benutzerhandbuch wurde nicht gefunden.")
+            return
+
+        try:
+            if sys.platform.startswith("win"):
+                os.startfile(str(manual_path))
+                result_code = 0
+            else:
+                cmd = ["open", str(manual_path)] if sys.platform == "darwin" else ["xdg-open", str(manual_path)]
+                completed = subprocess.run(cmd, check=False)
+                result_code = completed.returncode
+            if result_code not in (0, None):
+                raise RuntimeError(f"Rückgabecode {result_code}")
+            self._log("INFO", f"Benutzerhandbuch geöffnet: {manual_path}\n")
+        except Exception as exc:
+            messagebox.showerror("Benutzerhandbuch", f"Datei konnte nicht geöffnet werden: {exc}")
 
     def _open_inbox(self):
         path_value = (self.var_input.get() or "").strip()
@@ -704,6 +764,16 @@ class App(tk.Tk):
         if cfg.get("csv_log_path"):
             self.var_csv.set(True)
             self.var_csv_path.set(cfg.get("csv_log_path"))
+        fmt = str(
+            cfg.get("output_filename_format")
+            or self.filename_preset_map[self.default_filename_label]
+        )
+        label = self.filename_preset_inverse.get(fmt)
+        if label:
+            self.var_filename_pattern.set(label)
+        else:
+            self.var_filename_pattern.set(fmt)
+        self._update_filename_example()
     def _vars_to_cfg(self):
         cfg = {
             "input_dir": self.var_input.get(),
@@ -720,9 +790,31 @@ class App(tk.Tk):
             },
             "dry_run": bool(self.var_dry.get()),
         }
+        fmt = self._resolve_filename_format()
+        if fmt:
+            cfg["output_filename_format"] = fmt
         if self.var_csv.get():
             cfg["csv_log_path"] = self.var_csv_path.get()
         return cfg
+    def _resolve_filename_format(self):
+        selected = (self.var_filename_pattern.get() or "").strip()
+        if not selected:
+            return self.filename_preset_map.get(self.default_filename_label, "")
+        return self.filename_preset_map.get(selected, selected)
+    def _update_filename_example(self):
+        fmt = self._resolve_filename_format() or self.filename_preset_map.get(
+            self.default_filename_label, ""
+        )
+        try:
+            sample = fmt.format(
+                date=datetime.now().strftime("%Y-%m-%d"),
+                supplier="Lieferant",
+                invoice_no="RE-12345",
+                original_name="Originaldatei",
+            )
+        except Exception:
+            sample = fmt
+        self.var_filename_example.set(f"Beispiel: {sample}")
     def _save_config(self):
         cfg = self._vars_to_cfg()
         path = self.var_config_path.get() or DEFAULT_CONFIG_PATH


### PR DESCRIPTION
## Summary
- add configurable PDF filename format presets to the configuration view, including four new patterns beside the default
- store the resolved filename format in the configuration and show a live example for the current selection

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d2b75fe050832789cb0c6aca852624