### PR TITLE
Fix role normalization in GUI profile editor

### DIFF
--- a/gui_app.py
+++ b/gui_app.py
@@ -53,6 +53,8 @@ from pathlib import Path
 from types import SimpleNamespace
 from tkinter import filedialog, messagebox, ttk
 import yaml
+
+from roles_utils import normalize_roles
 # Importiere die vorhandene Logik aus sorter.py (erweiterte Version mit Callbacks)
 try:
     import sorter  # benötigt process_all(..., stop_fn, progress_fn) und Extraktions-Helpers
@@ -904,22 +906,16 @@ class App(tk.Tk):
             return
         self.roles_text.configure(state=tk.NORMAL)
         self.roles_text.delete("1.0", tk.END)
-        if roles:
-            lines = [str(role).strip() for role in roles if str(role).strip()]
-            if lines:
-                self.roles_text.insert("1.0", "\n".join(lines) + "\n")
+        cleaned = normalize_roles(roles)
+        if cleaned:
+            self.roles_text.insert("1.0", "\n".join(cleaned) + "\n")
         self.roles_text.edit_modified(False)
 
     def _get_roles_from_widget(self):
         if not hasattr(self, "roles_text"):
             return []
         content = self.roles_text.get("1.0", tk.END)
-        roles = []
-        for line in content.splitlines():
-            cleaned = line.strip()
-            if cleaned:
-                roles.append(cleaned)
-        return roles
+        return normalize_roles(content.splitlines())
     def _resolve_filename_format(self):
         selected = (self.var_filename_pattern.get() or "").strip()
         if not selected:
@@ -1014,7 +1010,7 @@ class App(tk.Tk):
     def _reload_roles_from_cfg(self):
         roles = []
         if isinstance(self.cfg, dict):
-            roles = self.cfg.get("roles") or []
+            roles = normalize_roles(self.cfg.get("roles") or [])
         self._set_roles_text(roles)
         self._log("INFO", "Rollen aus Konfiguration übernommen.\\n")
     def _clear_roles(self):

--- a/roles_utils.py
+++ b/roles_utils.py
@@ -1,0 +1,56 @@
+"""Utility helpers for working with role lists in configuration profiles."""
+
+from __future__ import annotations
+
+from typing import Iterable, List, Sequence
+
+
+def normalize_roles(raw: object) -> List[str]:
+    """Return a cleaned list of role strings from arbitrary input.
+
+    The GUI historically stored role information as a list of strings, but some
+    configurations may contain other structures (e.g. a single string such as
+    "admin" or nested sequences).  This helper normalises such inputs by:
+
+    * Accepting strings, sequences or any iterable value.
+    * Stripping whitespace from each item and dropping empty entries.
+    * Preserving the original order while removing duplicates.
+
+    Parameters
+    ----------
+    raw:
+        Value read from a configuration file or GUI widget.
+
+    Returns
+    -------
+    list[str]
+        A list containing the cleaned role names.
+    """
+
+    roles: List[str] = []
+    seen = set()
+
+    def _append(candidate: object) -> None:
+        if candidate is None:
+            return
+        if isinstance(candidate, str):
+            parts: Sequence[str] = candidate.splitlines() or [candidate]
+        elif isinstance(candidate, Iterable) and not isinstance(candidate, (bytes, bytearray)):
+            for item in candidate:
+                _append(item)
+            return
+        else:
+            parts = [str(candidate)]
+
+        for part in parts:
+            text = str(part).strip()
+            if not text:
+                continue
+            if text in seen:
+                continue
+            seen.add(text)
+            roles.append(text)
+
+    _append(raw)
+    return roles
+

--- a/tests/test_roles_utils.py
+++ b/tests/test_roles_utils.py
@@ -1,0 +1,15 @@
+from roles_utils import normalize_roles
+
+
+def test_normalize_roles_from_string():
+    assert normalize_roles("admin") == ["admin"]
+
+
+def test_normalize_roles_removes_empty_entries_and_duplicates():
+    raw = ["  admin  ", "", "admin", "finance"]
+    assert normalize_roles(raw) == ["admin", "finance"]
+
+
+def test_normalize_roles_handles_nested_iterables():
+    raw = ["manager\nteam", [" admin ", None], ("team", "support"), ["support"]]
+    assert normalize_roles(raw) == ["manager", "team", "admin", "support"]


### PR DESCRIPTION
## Summary
- normalise role values coming from configuration or the GUI so single-string entries such as "admin" are preserved
- reuse the new role normalisation helper inside the GUI when loading, saving and reloading profile roles
- add unit tests that cover role normalisation edge cases

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e54ad51bec832788599f91df55d621